### PR TITLE
Add Compatibility with MultiResponse

### DIFF
--- a/lib/mongoid/active_merchant/billing_response.rb
+++ b/lib/mongoid/active_merchant/billing_response.rb
@@ -13,6 +13,7 @@ module ActiveMerchant
       def as_json
         options = ATTRIBUTES_FOR_MONGOID_OPTIONS_SERIALIZATION.reduce({}) do |result, attr|
           value = instance_variable_get(:"@#{attr}")
+          value = send(attr) if value.nil? && respond_to?(attr)
           result[attr.to_s] = value unless value.nil?
           result
         end


### PR DESCRIPTION
ActiveMerchant::Billing::MultiResponse is an extension of ActiveMerchant::Billing::Response
that wraps multiple responses into one class. It does not set instance variables of the
response options, but rather defines getter methods to fetch these values from the primary response

If we want to store an instance of MultiResponse properly, we'll need to also check to see if the response
responds_to the field in question if it doesn't have an instance variable set for it.

This is just a suggested fix that resolves my problem. Please have a look and let me know what you think.