### PR TITLE
Fix `ArgumentError` on Pretty JSON Serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
+sudo: false
+services:
+  - mongodb
 rvm:
-  - 2.2.2
-before_install: gem install bundler -v 1.10.6
+  - 2.4
+  - 2.5
+  - 2.6
+before_install: gem install bundler

--- a/lib/mongoid/active_merchant/billing_response.rb
+++ b/lib/mongoid/active_merchant/billing_response.rb
@@ -31,7 +31,7 @@ module ActiveMerchant
       end
       alias_method :mongoize, :as_json
 
-      def to_json
+      def to_json(*)
         as_json.to_json
       end
 

--- a/mongoid-active_merchant.gemspec
+++ b/mongoid-active_merchant.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mongoid', '>= 4.0.0'
   spec.add_dependency 'activemerchant', '>= 1.52'
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", ">= 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "minitest-reporters"

--- a/test/mongoid/active_merchant_test.rb
+++ b/test/mongoid/active_merchant_test.rb
@@ -103,6 +103,7 @@ class Mongoid::ActiveMerchantTest < Minitest::Test
   def test_to_json
     as_json = @response.to_json
     result = ActiveMerchant::Billing::Response.demongoize(JSON.parse(as_json))
+    pretty = JSON.pretty_generate(@response.as_json)
 
     assert(result.success?)
     assert_equal(result.message, 'Success message')
@@ -116,5 +117,6 @@ class Mongoid::ActiveMerchantTest < Minitest::Test
     assert_equal(result.avs_result['code'], 'U')
     assert_equal(result.avs_result['street_match'], 'A')
     assert_equal(result.avs_result['postal_match'], 'B')
+    assert_includes(pretty, @response.message)
   end
 end


### PR DESCRIPTION
Some consumers pass arguments to `#to_json`, like
`JSON.pretty_generate`, so make sure the method in
`ActiveMerchant::Billing::Response` can handle any arguments. Currently,
calling `JSON.pretty_generate` on an
`ActiveMerchant::Billing::Response#to_json` will throw an argument
error.